### PR TITLE
Let users specify non-local repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ At this moment, it can only view and restore from snapshots.
 ### Development Scripts
 
 ```bash
+# install dependencies
+yarn install
+
 # run application in development mode
 yarn dev
 

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -56,15 +56,11 @@ fs.readFile(path.join(__static, "index.html"), (err, data) => {
     password =  document.configForm.password.value
     store.set("repo", repo)
 
-    fs.access(repo, fs.constants.R_OK, function (err) {
-      if (err) return dialog.showErrorBox("Error", "Directory does not exist.")
-
-      if (password.length > 0)
-        getSnapshots(repo, password)
-      else {
-        dialog.showErrorBox("Error", "Password required.")
-      }
-    })
+    if (password.length > 0)
+      getSnapshots(repo, password)
+    else {
+      dialog.showErrorBox("Error", "Password required.")
+    }
   })
 })
 


### PR DESCRIPTION
The check that the repo location exists in the file system made it impossible to use remote repos through rclone. This PR removes the check.

It also adds a step in the README to install dependencies.